### PR TITLE
change workflow to not upload zip in zip

### DIFF
--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -25,12 +25,8 @@ jobs:
     - name: Display compiled files
       run: find .
       
-    - name: Archive source code
-      run: |
-        zip -r source-code.zip *
-
-    - name: Upload artifact
+    - name: Upload source code artifact
       uses: actions/upload-artifact@v4
       with:
         name: source-code
-        path: source-code.zip
+        path: "**/*.java"


### PR DESCRIPTION
also becomes more accurate to name, since it no longer uploads compiled files